### PR TITLE
fix: isPrimitive を正しく全プリミティブ型に対応させる

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,11 +5,10 @@ function shallowCompareArray<T>(x: ReadonlyArray<T>, y: ReadonlyArray<T>): boole
   return [...Array(x.length).keys()].every((i) => x[i] === y[i]);
 }
 
-// string or number of boolean
-const primitiveHead = new RegExp('^[s|n|b]');
-
-function isPrimitive(x: unknown): boolean {
-  return primitiveHead.test(typeof x);
+/** export for test suite */
+export function isPrimitive(x: unknown): boolean {
+  const t = typeof x;
+  return t !== 'object' && t !== 'function';
 }
 
 /** export for test suite */

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import {describe, test, expect, vi, assertType} from 'vitest';
 
 import {createStore} from './index';
-import {shallowCompare} from './helpers';
+import {shallowCompare, isPrimitive} from './helpers';
 import {Observable} from './observable';
 
 const sleep = (time: number) => new Promise((resolve) => setTimeout(resolve, time)); //timeはミリ秒
@@ -139,6 +139,24 @@ describe('Store', () => {
 
     store.actions.handleChange('newA', 'newB');
     expect(store.getState()).toStrictEqual({a: 'a!!!->newA', b: 'b!->newB'});
+  });
+});
+
+describe('isPrimitive', () => {
+  test('returns true for all JS primitive types', () => {
+    expect(isPrimitive('hello')).toBe(true);
+    expect(isPrimitive(42)).toBe(true);
+    expect(isPrimitive(true)).toBe(true);
+    expect(isPrimitive(undefined)).toBe(true);
+    expect(isPrimitive(Symbol('s'))).toBe(true);
+    expect(isPrimitive(42n)).toBe(true);
+  });
+
+  test('returns false for non-primitive types', () => {
+    expect(isPrimitive(null)).toBe(false);
+    expect(isPrimitive({})).toBe(false);
+    expect(isPrimitive([])).toBe(false);
+    expect(isPrimitive(() => {})).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- `isPrimitive` の正規表現 `^[s|n|b]` を `typeof` チェックに置き換え
- 旧実装の問題点:
  - 文字クラス内の `|` がリテラル文字として扱われる（意図しない記述）
  - `typeof undefined === 'undefined'` は `u` で始まるためマッチせず、`undefined` をプリミティブと判定できない
- 新実装: `typeof x !== 'object' && typeof x !== 'function'` で string / number / boolean / undefined / symbol / bigint を正しく網羅

## Approach

テストファーストで実施:
1. `isPrimitive` を `export` してテスト可能にする
2. `isPrimitive(undefined)` が `true` になるべきというテストを追加 → **Red**
3. 実装を修正 → **Green**

## Test plan

- [x] `isPrimitive` の専用テストスイートを追加（全プリミティブ型・非プリミティブ型を網羅）
- [x] `vitest run` — 全 9 テスト通過
- [x] `biome lint` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)