### PR TITLE
fix: テストファイルのビルド混入を解消・CI を最新化

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -9,34 +9,28 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
-    - uses: actions/checkout@v1
     - name: Cache node_modules
-      uses: actions/cache@preview
+      id: cache
+      uses: actions/cache@v4
       with:
         path: ~/.cache/yarn
-        key: ${{ runner.os }}-projectname-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
-        restore-keys:
-          ${{ runner.os }}-projectname-
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Install node_modules
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        npm install -g yarn
-        yarn install
+      run: yarn install
 
-    - name: Lint
-      run: |
-        yarn check-all
-
-    - name: Test
-      run: |
-        yarn test
+    - name: Lint and Test
+      run: yarn check-all

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "test": "vitest run",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "check:lint": "biome lint src/ --vcs-use-ignore-file=true",
     "check:style": "biome format src/ --vcs-use-ignore-file=true",
     "check:type": "npm run build --noEmit",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["./src/**/*.test.ts", "./src/**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary

### dist へのテストファイル混入を修正
- `tsconfig.build.json` を新設し、`tsconfig.json` を extends しつつ `*.test.ts` / `*.test.tsx` を exclude
- `package.json` の `build` スクリプトを `tsc -p tsconfig.build.json` に変更
- クリーンビルド後の `dist/` から `index.test.*` / `dom-integration.test.*` が消えたことを確認

### CI を最新化
- `actions/checkout@v1` → `v4`
- `actions/setup-node@v1` → `v4`
- `actions/cache@preview` → `v4`
- 重複していた `checkout` ステップを削除
- cache step の id 参照を修正
- Node.js `18.x` → `22.x`
- `npm install -g yarn` を削除（runner に yarn は標準で入っている）
- check-all がテストを含むため、冗長な別 Test ステップを削除

## Test plan

- [x] `npm run clean && npm run build` → dist に `*.test.*` が含まれないことを確認
- [x] `npm run check-all` — 全 9 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)