### PR TITLE
docs: 公開 API 全体に JSDoc コメントとサンプルコードを追加

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,13 +5,31 @@ function shallowCompareArray<T>(x: ReadonlyArray<T>, y: ReadonlyArray<T>): boole
   return [...Array(x.length).keys()].every((i) => x[i] === y[i]);
 }
 
-/** export for test suite */
+/** @internal */
 export function isPrimitive(x: unknown): boolean {
   const t = typeof x;
   return t !== 'object' && t !== 'function';
 }
 
-/** export for test suite */
+/**
+ * Compares two values with shallow equality.
+ *
+ * - **Primitives** (`string`, `number`, `boolean`, `undefined`, `symbol`, `bigint`)
+ *   and `null` are compared with `Object.is`.
+ * - **Arrays** are compared element-by-element with `===` (one level deep).
+ * - **Plain objects** are compared key-by-key with `Object.is` (one level deep).
+ *   Nested arrays within object values are themselves compared shallowly.
+ *
+ * Used as the default equality function for `useSelector`, so returning a
+ * freshly constructed object or array from a selector does not cause
+ * unnecessary re-renders as long as its contents are reference-equal.
+ *
+ * @example
+ * shallowCompare('a', 'a');                     // true
+ * shallowCompare([1, 2], [1, 2]);               // true  — same elements
+ * shallowCompare({a: 1, b: 2}, {a: 1, b: 2});  // true  — same keys & values
+ * shallowCompare({a: {b: 1}}, {a: {b: 1}});    // false — nested objects are not deep-compared
+ */
 export function shallowCompare<T>(x: T, y: T): boolean {
   if (Object.is(x, y)) {
     return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,18 +12,155 @@ type Setter<State> = Updater<State> | ((updater: Updater<State>) => void);
 type BehaviorReturn<State> = (s: State) => State | Promise<State> | Observable<(current: State) => State>;
 type Behavior<State, Args extends ReadonlyArray<any>> = (...args: Args) => BehaviorReturn<State>;
 
+/**
+ * The store object returned by {@link createStore}.
+ * Provides a React hook, raw subscriptions, and fully-typed action dispatchers.
+ */
 export type Subscriber<State, Behaviors extends Record<string, Behavior<Readonly<State>, any>>> = {
-  subscribe: (sub: (state: Readonly<State>) => void) => void;
-  useSelector: <Selection>(selector: (s: Readonly<State>) => Selection, isEqual?: (a: Selection, b: Selection) => boolean) => Selection;
-  getState(): Readonly<State>;
-  setState: Setter<Readonly<State>>;
   /**
-   * [actions] will change a state of Store.
-   * Store is able to handle plain object, Promise<T> and also Observable<T>
+   * Subscribes to every state change outside of React.
+   * Useful for side effects such as logging, persistence, or analytics.
+   *
+   * @param sub - Called with the new state after each update.
+   * @returns An unsubscribe function. Call it to stop listening.
+   *
+   * @example
+   * const unsubscribe = store.subscribe((state) => {
+   *   localStorage.setItem('appState', JSON.stringify(state));
+   * });
+   * // later:
+   * unsubscribe();
+   */
+  subscribe: (sub: (state: Readonly<State>) => void) => void;
+
+  /**
+   * React hook that subscribes to a derived slice of store state.
+   * Re-renders only when the selected value changes according to `isEqual`.
+   * Defaults to shallow comparison, so returning plain objects or arrays
+   * from the selector does not cause unnecessary re-renders.
+   *
+   * @param selector - Derives the value of interest from the full state.
+   * @param isEqual - Custom equality function. Defaults to {@link shallowCompare}.
+   *
+   * @example
+   * function UserCard() {
+   *   const name = userStore.useSelector((s) => s.user.name);
+   *   return <span>{name}</span>;
+   * }
+   *
+   * @example
+   * // Custom equality — only re-render when the id actually changes
+   * const id = store.useSelector((s) => s.user.id, (a, b) => a === b);
+   */
+  useSelector: <Selection>(selector: (s: Readonly<State>) => Selection, isEqual?: (a: Selection, b: Selection) => boolean) => Selection;
+
+  /**
+   * Returns the current state synchronously.
+   * Prefer {@link useSelector} inside React components.
+   */
+  getState(): Readonly<State>;
+
+  /**
+   * Directly sets the store state, bypassing behaviors.
+   * Accepts either a replacement value or an updater function `(prev) => next`.
+   *
+   * Prefer defining a behavior when possible — behaviors are pure functions
+   * that are easy to test in isolation and make state transitions explicit.
+   *
+   * @example
+   * store.setState({count: 0});                        // replace
+   * store.setState((prev) => ({...prev, count: 0}));   // update
+   */
+  setState: Setter<Readonly<State>>;
+
+  /**
+   * Dispatches a behavior to update the store state.
+   * The store transparently handles behaviors that return a plain state,
+   * a `Promise`, or an `Observable`.
+   *
+   * @example
+   * store.actions.increment();              // sync
+   * await store.actions.fetchUser('42');    // async
+   * store.actions.streamLogs('query');      // Observable streaming
    */
   actions: {[P in keyof Behaviors]: (...args: Parameters<Behaviors[P]>) => ReturnType<ReturnType<Behaviors[P]>>};
 };
 
+/**
+ * Creates a type-safe reactive store for React.
+ *
+ * Each behavior is a curried pure function of the form
+ * `(args) => (prevState) => nextState`.
+ * Behaviors can return a plain state value, a `Promise`, or an `Observable`
+ * for streaming updates — the store handles all three automatically.
+ *
+ * @param initialState - The initial state of the store.
+ * @param behaviors - An object of state-transition functions. Each key is an
+ *   action name; each value receives call arguments and returns a function from
+ *   the previous state to the next state (or a `Promise`/`Observable` thereof).
+ * @param middleware - Optional lifecycle hooks applied to every state transition.
+ *   See {@link Middleware}.
+ * @returns A {@link Subscriber} with `actions`, `useSelector`, `subscribe`,
+ *   `getState`, and `setState`.
+ *
+ * @example
+ * // Synchronous behaviors
+ * const counterStore = createStore(
+ *   {count: 0},
+ *   {
+ *     increment: () => (s) => ({...s, count: s.count + 1}),
+ *     decrement: () => (s) => ({...s, count: s.count - 1}),
+ *     setCount:  (n: number) => (_s) => ({count: n}),
+ *   },
+ * );
+ *
+ * counterStore.actions.increment(); // state becomes {count: 1}
+ *
+ * function Counter() {
+ *   const count = counterStore.useSelector((s) => s.count);
+ *   return <button onClick={() => counterStore.actions.increment()}>{count}</button>;
+ * }
+ *
+ * @example
+ * // Async behavior (Promise)
+ * const userStore = createStore(
+ *   {user: null as User | null},
+ *   {
+ *     fetchUser: (id: string) => async (s) => {
+ *       const user = await api.getUser(id);
+ *       return {...s, user};
+ *     },
+ *   },
+ * );
+ *
+ * await userStore.actions.fetchUser('42');
+ *
+ * @example
+ * // Streaming behavior (Observable) — e.g. WebSocket or chunked HTTP
+ * const chatStore = createStore(
+ *   {messages: [] as string[]},
+ *   {
+ *     streamRoom: (roomId: string) => (_s) =>
+ *       new Observable((obs) => {
+ *         const ws = new WebSocket(`wss://example.com/rooms/${roomId}`);
+ *         ws.onmessage = (e) => obs.next((s) => ({...s, messages: [...s.messages, e.data]}));
+ *         ws.onerror  = () => obs.error(new Error('connection lost'));
+ *         ws.onclose  = () => obs.complete();
+ *       }),
+ *   },
+ * );
+ *
+ * @example
+ * // Middleware — logging every transition
+ * const store = createStore(
+ *   initialState,
+ *   behaviors,
+ *   {
+ *     onInit:   (s) => { console.log('init', s); return s; },
+ *     onUpdate: (next, prev) => { console.log(prev, '->', next); return next; },
+ *   },
+ * );
+ */
 export function createStore<State, Behaviors extends Record<string, Behavior<State, any>>>(
   initialState: State,
   behaviors: Behaviors,

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -3,10 +3,16 @@ const ERROR_EVENT_TYPE = 'error' as const;
 const COMPLETE_EVENT_TYPE = 'complete' as const;
 
 /**
- * The resolved Symbol.observable value, with a fallback for environments that don't support it.
- * Exported so users can reference it directly (e.g. for their own type augmentation).
+ * The resolved `Symbol.observable` value, with a fallback for environments
+ * that do not yet expose it on `Symbol`.
  *
- * To enable TypeScript type checking on the interop protocol, add this to your project:
+ * Exported so consumers can reference it directly — for example when
+ * integrating with libraries that read `Symbol.observable` at runtime,
+ * or when writing their own TypeScript type augmentations.
+ *
+ * If you want TypeScript to type-check `obj[Symbol.observable]()` calls
+ * in your project, add the following declaration once (e.g. in a `.d.ts` file):
+ *
  * @example
  * declare global {
  *   interface SymbolConstructor { readonly observable: symbol; }
@@ -14,6 +20,10 @@ const COMPLETE_EVENT_TYPE = 'complete' as const;
  */
 export const symbolObservable: symbol = (Symbol as {observable?: symbol}).observable ?? Symbol('observable');
 
+/**
+ * Thrown when the Observable producer emits `next` after `complete`
+ * has already been signalled. Not normally encountered by library consumers.
+ */
 export class ObservableCompletedError extends Error {}
 
 type Subscriber<V> = {
@@ -23,7 +33,33 @@ type Subscriber<V> = {
 };
 
 /**
- * Small implementation of https://tc39.es/proposal-observable/
+ * A lightweight multicast Observable based on the
+ * {@link https://tc39.es/proposal-observable/ TC39 Observable proposal}.
+ *
+ * **Lazy & multicast**: the producer function runs only when the first
+ * subscriber attaches. All subsequent subscribers share that single producer
+ * via an internal `EventTarget` bus.
+ *
+ * Use `Observable` as a behavior return type when a single user action needs
+ * to push multiple state updates over time — streaming API responses,
+ * WebSocket messages, animation frames, etc.
+ *
+ * @example
+ * // Inside a createStore behavior — stream server-sent events into state
+ * const store = createStore(
+ *   {lines: [] as string[]},
+ *   {
+ *     streamLogs: (query: string) => (_s) =>
+ *       new Observable<(s: {lines: string[]}) => {lines: string[]}>((obs) => {
+ *         const es = new EventSource(`/logs?q=${query}`);
+ *         es.onmessage = (e) => obs.next((s) => ({...s, lines: [...s.lines, e.data]}));
+ *         es.onerror   = () => obs.error(new Error('stream failed'));
+ *         es.addEventListener('done', () => { obs.complete(); es.close(); });
+ *       }),
+ *   },
+ * );
+ *
+ * store.actions.streamLogs('error');
  */
 export class Observable<V> {
   private readonly evt = new EventTarget();
@@ -55,12 +91,47 @@ export class Observable<V> {
   }
 
   /**
-   * @param observe observe won't be called until [subscribe] called
+   * @param observe The producer function. Receives a subscriber object with
+   *   three callbacks. Executed lazily — called only when the first observer
+   *   subscribes.
+   *   - `next(value)` — push the next value to all subscribers.
+   *     No-op after `complete()` has been called.
+   *   - `error(err)` — signal a terminal error. Delivers the error to all
+   *     subscribers and stops further emissions.
+   *   - `complete()` — signal that the stream has ended normally. Subsequent
+   *     `next` calls are silently ignored.
    */
   public constructor(private readonly observe: (subscriber: Subscriber<V>) => void) {}
 
   /**
-   * @returns unsubscribe
+   * Attaches an observer to the Observable.
+   * The producer starts on the first call; subsequent calls share the same
+   * running producer (multicast).
+   *
+   * @param observer.next - Receives each emitted value.
+   * @param observer.error - Called if the producer signals failure (optional).
+   * @param observer.complete - Called once when the producer signals the end of
+   *   the stream (optional).
+   * @returns An unsubscribe function. Calling it detaches only this observer;
+   *   other observers are unaffected and the producer keeps running.
+   *
+   * @example
+   * const obs = new Observable<number>((sub) => {
+   *   let i = 0;
+   *   const id = setInterval(() => {
+   *     if (i >= 3) { sub.complete(); clearInterval(id); return; }
+   *     sub.next(i++);
+   *   }, 100);
+   * });
+   *
+   * const unsubscribe = obs.subscribe({
+   *   next:     (v) => console.log('value', v),
+   *   error:    (e) => console.error('error', e),
+   *   complete: ()  => console.log('done'),
+   * });
+   *
+   * // Stop early if needed:
+   * // unsubscribe();
    */
   public subscribe = (observer: {next: (v: V) => void; error?: (err: unknown) => void; complete?: () => void}): VoidFunction => {
     const innerUpdateSub = () => {
@@ -95,9 +166,13 @@ export class Observable<V> {
 }
 
 /**
- * Implements the Observable interop protocol (Symbol.observable).
- * Using Object.defineProperty because TypeScript's computed property syntax
- * requires a unique symbol, but symbolObservable is typed as symbol.
+ * Implements the Observable interop protocol (`Symbol.observable`).
+ * Enables this Observable to be consumed by RxJS and any library that
+ * checks `Symbol.observable` for duck-typing.
+ *
+ * Uses `Object.defineProperty` because TypeScript's computed property syntax
+ * in class bodies requires a `unique symbol`, but {@link symbolObservable}
+ * is typed as `symbol`.
  */
 Object.defineProperty(Observable.prototype, symbolObservable, {
   value<V>(this: Observable<V>): Observable<V> {

--- a/src/subscribable.ts
+++ b/src/subscribable.ts
@@ -1,19 +1,75 @@
 const UPDATE_EVENT = 'update';
 
+/**
+ * Lifecycle hooks that intercept state transitions in a {@link Subscribable}.
+ * Pass as the third argument to {@link createStore} to apply cross-cutting
+ * concerns such as logging, validation, or time-travel debugging.
+ *
+ * @example
+ * const loggingMiddleware: Middleware<AppState> = {
+ *   onInit: (s) => {
+ *     console.log('[store] init', s);
+ *     return s;
+ *   },
+ *   onUpdate: (next, prev) => {
+ *     console.log('[store]', prev, '->', next);
+ *     return next;
+ *   },
+ * };
+ *
+ * const store = createStore(initialState, behaviors, loggingMiddleware);
+ */
 export type Middleware<State> = {
+  /**
+   * Called once with the initial state before the store becomes active.
+   * Return the (optionally transformed) initial state that the store should use.
+   *
+   * @example
+   * // Rehydrate from localStorage on startup
+   * onInit: (s) => ({...s, ...JSON.parse(localStorage.getItem('state') ?? '{}')}),
+   */
   onInit?: (s: State) => State;
+
+  /**
+   * Called on every state transition. Return the value that should actually
+   * be stored — return `next` unchanged if you only want to observe the change.
+   *
+   * @param newState - The proposed next state produced by the behavior.
+   * @param prevState - The state before this transition.
+   *
+   * @example
+   * // Clamp a numeric field so it never goes below zero
+   * onUpdate: (next, _prev) => ({...next, count: Math.max(0, next.count)}),
+   */
   onUpdate?: (newState: State, prevState: State) => State;
 };
 
+/**
+ * Low-level reactive state container backed by the DOM `EventTarget` API.
+ *
+ * Used internally by {@link createStore}. Exposed for advanced use cases
+ * such as building custom store wrappers or integrating with non-React
+ * environments.
+ *
+ * Most users should interact with the store via the object returned by
+ * {@link createStore} rather than using `Subscribable` directly.
+ */
 export class Subscribable<State> {
   private readonly evt = new EventTarget();
 
   private state: State;
 
+  /**
+   * Returns the current state synchronously.
+   */
   public getState = (): State => {
     return this.state;
   };
 
+  /**
+   * @param initialState - The starting state.
+   * @param eventHook - Optional {@link Middleware} applied to `onInit` and every `onUpdate`.
+   */
   constructor(
     initialState: State,
     private readonly eventHook?: Middleware<State>,
@@ -22,8 +78,10 @@ export class Subscribable<State> {
   }
 
   /**
-   * @param sub
-   * @returns unsubscribe
+   * Subscribes to every state change.
+   *
+   * @param sub - Callback invoked with the new state after each update.
+   * @returns An unsubscribe function.
    */
   public subscribe = (sub: (state: State) => void): VoidFunction => {
     const innerSub = () => {
@@ -33,6 +91,13 @@ export class Subscribable<State> {
     return () => this.evt.removeEventListener('update', innerSub);
   };
 
+  /**
+   * Transitions the store to a new state, applies any `onUpdate` middleware,
+   * and notifies all subscribers.
+   *
+   * @param newState - The next state value.
+   * @returns The state that was actually stored (after middleware).
+   */
   public update = (newState: State): State => {
     const newState_ = this.eventHook?.onUpdate?.call(null, newState, this.state) ?? newState;
     this.state = newState_;


### PR DESCRIPTION
## Summary

エディタのホバー補完や型生成ツール（typedoc 等）で読めるよう、export される API 全体に JSDoc を追加。

### 対象ファイルと主な内容

| ファイル | 追加内容 |
|---|---|
| `index.ts` | `createStore` に sync / Promise / Observable + middleware の全パターンサンプル。`Subscriber` 型の各メンバー (`useSelector` / `subscribe` / `setState` / `actions`) に説明とサンプル |
| `observable.ts` | `Observable` クラス概要（lazy & multicast の挙動）、コンストラクタの `next` / `error` / `complete` コールバック説明、`subscribe` の返り値と複数 subscriber の挙動 |
| `subscribable.ts` | `Middleware` 型の `onInit` / `onUpdate` に用途と具体的なサンプル。`Subscribable` を低レベル API として位置付けるコメント |
| `helpers.ts` | `shallowCompare` の比較ルールと境界ケース（ネストオブジェクトは非対応）を明記。`isPrimitive` に `@internal` タグ |

## Test plan

- [x] `npm run check-all` 全件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)