### PR TITLE
docs: README を全面改訂 — ライブラリの独自性を前面に

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,141 @@
 [![Lint Check](https://github.com/hachibeeDI/nozuchi/actions/workflows/checker.yml/badge.svg)](https://github.com/hachibeeDI/nozuchi/actions/workflows/checker.yml)
 
-# Nozuchi
+# nozuchi
 
-A simple state management tool.
+A minimal, type-safe React state management library built around **curried, pure-functional behaviors**.
 
-Features:
+```
+npm install nozuchi
+```
 
-- typesafe
-- functional
-- supports Promise
-- supports Observable
+---
 
-## Example
+## Why nozuchi?
 
-### Sync example
+Most React state libraries ask you to mutate state or dispatch action objects. nozuchi takes a different approach: every state change is expressed as a **curried pure function**.
 
-```typescript
-const initialState = {count: 0, b: 'b'};
-const store = createStore(initialState, {
-  // (arg: T) => (previousStore: S) => S;
-  handleAClicked: () => (prev) => ({...prev, count: prev.count + 1}),
-});
+```ts
+// A behavior: (args) => (prevState) => nextState
+increment: () => (s) => ({...s, count: s.count + 1})
+```
 
-// supports React hooks integration
-const [c] = store.useSelector((s) => [s.count]);
-return (
-  <div>
-    <button
-      // call your methods via `actions`
-      onClick={store.actions.handleAClicked}
-    >clicked {c} times</button>
-  </div>
+This one pattern scales to all three update modes — synchronous, async, and streaming — with no extra API to learn:
+
+| Return type | Use case |
+|---|---|
+| `State` | Synchronous update |
+| `Promise<State>` | Single async result (fetch, etc.) |
+| `Observable<(State) => State>` | Stream of updates (WebSocket, SSE, etc.) |
+
+Behaviors are plain functions. You can unit-test them without instantiating a store, mock nothing, and the types flow end-to-end without casting.
+
+---
+
+## Quick start
+
+```ts
+import {createStore, Observable} from 'nozuchi';
+
+type State = {
+  count: number;
+  user: string | null;
+  log: string[];
+};
+
+const store = createStore(
+  {count: 0, user: null, log: []} satisfies State,
+  {
+    // Sync — returns next state directly
+    increment: () => (s) => ({...s, count: s.count + 1}),
+
+    // Async — returns a Promise
+    loadUser: (id: string) => async (s) => {
+      const res = await fetch(`/api/users/${id}`);
+      const user = await res.json();
+      return {...s, user: user.name};
+    },
+
+    // Streaming — returns an Observable for multiple updates over time
+    streamLogs: (query: string) => (_s) =>
+      new Observable((obs) => {
+        const es = new EventSource(`/api/logs?q=${query}`);
+        es.onmessage = (e) => obs.next((s) => ({...s, log: [...s.log, e.data]}));
+        es.onerror   = () => obs.error(new Error('stream failed'));
+        es.addEventListener('done', () => { obs.complete(); es.close(); });
+      }),
+  },
 );
 ```
 
-### Promise sample
+### In a React component
 
-```typescript
-const sleep = (time: number) => new Promise((resolve) => setTimeout(resolve, time)); //timeはミリ秒
+```tsx
+function Counter() {
+  // Re-renders only when count changes
+  const count = store.useSelector((s) => s.count);
 
-const store = createStore(initialState, {
-  handleAChangedAsync: (newA: string) => async (prev) => {
-    await sleep(1);
-    return {...prev, a: newA};
+  return (
+    <button onClick={() => store.actions.increment()}>
+      clicked {count} times
+    </button>
+  );
+}
+```
+
+### Outside React
+
+```ts
+// Raw subscription — useful for persistence, logging, analytics
+const unsubscribe = store.subscribe((state) => {
+  localStorage.setItem('state', JSON.stringify(state));
+});
+
+// Dispatch actions anywhere
+store.actions.increment();
+await store.actions.loadUser('42');
+store.actions.streamLogs('error');
+```
+
+---
+
+## Middleware
+
+Intercept every state transition with `onInit` and `onUpdate` hooks:
+
+```ts
+const store = createStore(
+  initialState,
+  behaviors,
+  {
+    // Transform initial state (e.g. rehydrate from storage)
+    onInit: (s) => ({...s, ...JSON.parse(localStorage.getItem('state') ?? '{}')}),
+
+    // Intercept every update (e.g. logging, validation, time-travel)
+    onUpdate: (next, prev) => {
+      console.log('[store]', prev, '->', next);
+      return next;
+    },
   },
+);
+```
+
+---
+
+## Testing behaviors
+
+Because behaviors are plain functions, they need no store to test:
+
+```ts
+import {increment, loadUser} from './store';
+
+test('increment adds 1', () => {
+  const result = increment()({count: 0, user: null, log: []});
+  expect(result.count).toBe(1);
 });
 ```
 
-### Observable sample
+---
 
-```typescript
-const initialState = {a: 'a', b: 'b'};
-type TestState = typeof initialState;
+## RxJS interoperability
 
-const store = createStore(initialState, {
-  handleAChangedStream: (watcher: () => void) => (_prev) =>
-    new Observable<(s: TestState) => TestState>(async (obs) => {
-      await sleep(1);
-      obs.next((current) => ({...current, a: `${current.a}-${initialState.a}`}));
-      await sleep(1);
-      obs.next((current) => ({...current, a: `${current.a}-${initialState.a}`}));
-      await sleep(1);
-      obs.next((current) => ({...current, a: `${current.a}-${initialState.a}`}));
-      await sleep(1);
-      obs.complete();
-      watcher();
-    }),
-});
-```
+nozuchi's `Observable` implements the `Symbol.observable` protocol, so it works with `from()`, `merge()`, `concat()`, and any RxJS operator out of the box.


### PR DESCRIPTION
## Summary

既存 README を全面的に書き直し。

### 変更の意図

- 「シンプルな状態管理ツール」という説明では他と差別化できない
- カリー化 behavior という設計が持つ **型安全性・関数型指向・リアクティブサポート** の組み合わせが希少である点を冒頭で伝える

### 構成

1. **Why nozuchi?** — `(args) => (prevState) => nextState` というパターンと、sync / Promise / Observable の三形態を一つの API で統一できることを即座に提示
2. **Quick start** — 現実的なユースケース（カウンター・fetch・SSE）を一つのストアにまとめて全形態を見せる
3. **React 内 / React 外** — `useSelector` と `subscribe` の使い分けを分けて説明
4. **Middleware** — rehydrate や logging の具体例
5. **Testing behaviors** — ストアを生成せずに behavior 単体をテストできる点を強調
6. **RxJS interoperability** — Symbol.observable 対応を一言で紹介

## Test plan

- [x] Markdown のレンダリング確認（見出し・テーブル・コードブロック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)