### PR TITLE
feat: v* タグで npm publish する CI ワークフローを追加

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Cache yarn packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install dependencies
+      run: yarn install
+
+    - name: Publish
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for npm Trusted Publishing (OIDC)
 
     steps:
     - uses: actions/checkout@v4
@@ -29,6 +31,4 @@ jobs:
       run: yarn install
 
     - name: Publish
-      run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish --provenance

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:style": "biome format src/ --vcs-use-ignore-file=true",
     "check:type": "npm run build --noEmit",
     "check-all": "npm run check:style && npm run check:lint && npm run check:type && npm run test",
-    "prepublish": "npm run check-all && npm run build"
+    "prepublishOnly": "npm run check-all && npm run build"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

- `.github/workflows/publish.yml` を新設 — `v*` タグ push で自動的に npm publish
- `prepublish` → `prepublishOnly` に修正（`npm install` 時に不要なフックが走るのを防ぐ）

## 仕組み

```
git tag v0.0.14 && git push origin v0.0.14
         ↓
GitHub Actions: publish.yml 起動
         ↓
yarn install → npm publish
         ↓ (prepublishOnly が自動実行)
biome format / lint → tsc (型チェック) → vitest → tsc -p tsconfig.build.json
         ↓
npm registry へ公開
```

lint・型チェック・テスト・ビルドはすべて `prepublishOnly` が担うため、ワークフロー自体はシンプルに保てています。

## マージ前に必要な設定

リポジトリの **Settings › Secrets and variables › Actions** に以下を登録してください:

| Secret 名 | 値 |
|---|---|
| `NPM_TOKEN` | npmjs.com の **Automation** タイプのアクセストークン |

## Test plan

- [x] ワークフロー YAML の構文確認
- [x] `prepublishOnly` に変更後もローカルで `npm run check-all` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)